### PR TITLE
feat: Refactor repositories to use user-specific Firestore paths and …

### DIFF
--- a/app/src/main/java/com/example/accessoriesManager/adapter/HeadquarterAdapter.kt
+++ b/app/src/main/java/com/example/accessoriesManager/adapter/HeadquarterAdapter.kt
@@ -10,6 +10,8 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.accesorymanager.R
 import com.example.accessoriesManager.model.Headquarter
+import java.text.NumberFormat
+import java.util.Locale
 
 class HeadquarterAdapter(
     private val onView: (Headquarter) -> Unit,
@@ -36,7 +38,9 @@ class HeadquarterAdapter(
 
         fun bind(item: Headquarter) {
             tvName.text = item.name
-            tvInc.text = "Incremento: ${item.increment}"
+            tvInc.text = "Incremento: $ ${
+                NumberFormat.getInstance(Locale("es", "CO")).format(item.increment)
+            }"
             itemView.setOnClickListener { onEdit(item) }
 //          btnView.setOnClickListener { onView(item) }
             btnEdit.setOnClickListener { onEdit(item) }

--- a/app/src/main/java/com/example/accessoriesManager/form/HeadquarterFormFragment.kt
+++ b/app/src/main/java/com/example/accessoriesManager/form/HeadquarterFormFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.example.accesorymanager.R
 import com.example.accesorymanager.databinding.FragmentFormBaseBinding
+import com.example.accessoriesManager.ui.ThousandsSeparatorTextWatcher
 import com.example.accessoriesManager.ui.showSnack
 import com.example.accessoriesManager.viewmodel.HeadquarterFormViewModel
 import com.google.android.material.textfield.TextInputEditText
@@ -48,6 +49,9 @@ class HeadquarterFormFragment : Fragment(R.layout.fragment_form_base) {
         val etIncrement =
             binding.formFieldsContainer.findViewById<TextInputEditText>(R.id.etIncrement)
 
+        // ✅ Formatear incremento con puntos de miles mientras escribe (igual que precio)
+        etIncrement.addTextChangedListener(ThousandsSeparatorTextWatcher(etIncrement))
+
         // Defaults
         etIncrement.setText("0")
 
@@ -68,9 +72,14 @@ class HeadquarterFormFragment : Fragment(R.layout.fragment_form_base) {
         // Guardar / Actualizar (mismo flujo)
         binding.btnSave.setOnClickListener {
             etName.error = null
+            etIncrement.error = null
 
             val name = etName.text?.toString().orEmpty()
-            val incRaw = etIncrement.text?.toString()
+
+            // ✅ quitar puntos para mandar el número limpio al VM
+            val incRaw = etIncrement.text
+                ?.toString()
+                ?.replace(".", "")
 
             viewModel.save(
                 id = editId,
@@ -101,6 +110,13 @@ class HeadquarterFormFragment : Fragment(R.layout.fragment_form_base) {
 
                         is HeadquarterFormViewModel.UiState.NameError -> {
                             etName.error = state.msg
+                            binding.btnSave.isEnabled = true
+                            binding.btnSave.text = normalText
+                        }
+
+                        // ✅ Igual que en Accesorios: error específico del número
+                        is HeadquarterFormViewModel.UiState.IncrementError -> {
+                            etIncrement.error = state.msg
                             binding.btnSave.isEnabled = true
                             binding.btnSave.text = normalText
                         }
@@ -136,6 +152,7 @@ class HeadquarterFormFragment : Fragment(R.layout.fragment_form_base) {
                 viewModel.form.collect { hq ->
                     hq?.let {
                         etName.setText(it.name)
+                        // ✅ setea el incremento y el watcher lo formatea solo
                         etIncrement.setText(it.increment.toString())
                     }
                 }

--- a/app/src/main/java/com/example/accessoriesManager/viewmodel/HeadquarterFormViewModel.kt
+++ b/app/src/main/java/com/example/accessoriesManager/viewmodel/HeadquarterFormViewModel.kt
@@ -22,7 +22,10 @@ class HeadquarterFormViewModel @Inject constructor(
         data object Idle : UiState()
         data object Checking : UiState()
         data object Saving : UiState()
+
         data class NameError(val msg: String) : UiState()
+        data class IncrementError(val msg: String) : UiState() // 👈 AQUÍ
+
         data class Success(val msg: String = "Sede guardada correctamente ✅") : UiState()
         data class Error(val msg: String) : UiState()
     }


### PR DESCRIPTION
This pull request improves the handling and display of the "increment" field for headquarters, ensuring better user experience and data consistency. The changes add thousands separators for better readability, sanitize input before saving, and provide specific error feedback for invalid increment values.

**Increment field formatting and validation:**

* Added a `ThousandsSeparatorTextWatcher` to the `etIncrement` field in `HeadquarterFormFragment` so that as users type, the increment value is formatted with thousands separators (e.g., "1.000" instead of "1000"). (`app/src/main/java/com/example/accessoriesManager/form/HeadquarterFormFragment.kt`) [[1]](diffhunk://#diff-d41460bd2d587a18044be62b6b05cb8fbadb6ecf729ed296105ba41bca2b21d3R14) [[2]](diffhunk://#diff-d41460bd2d587a18044be62b6b05cb8fbadb6ecf729ed296105ba41bca2b21d3R52-R54) [[3]](diffhunk://#diff-d41460bd2d587a18044be62b6b05cb8fbadb6ecf729ed296105ba41bca2b21d3R155)
* When saving, the code now strips out thousands separators from the increment value before passing it to the ViewModel, ensuring the value is stored as a clean number. (`app/src/main/java/com/example/accessoriesManager/form/HeadquarterFormFragment.kt`)

**User feedback improvements:**

* Added a specific error state and message for increment validation errors, similar to how accessory forms handle price errors. (`app/src/main/java/com/example/accessoriesManager/form/HeadquarterFormFragment.kt`, `app/src/main/java/com/example/accessoriesManager/viewmodel/HeadquarterFormViewModel.kt`) [[1]](diffhunk://#diff-d41460bd2d587a18044be62b6b05cb8fbadb6ecf729ed296105ba41bca2b21d3R117-R123) [[2]](diffhunk://#diff-d3e512104e10c3e8572aa636d9bec7565547b82f9f99b552bf2ceb2492e62d7dR25-R28)

**Display improvements:**

* Updated the `HeadquarterAdapter` to display the increment value with thousands separators using the Colombian Spanish locale, improving readability in the headquarters list. (`app/src/main/java/com/example/accessoriesManager/adapter/HeadquarterAdapter.kt`) [[1]](diffhunk://#diff-c6fd169b20ce5338b7e591ee0a8eed681d6bfbe936e3f0c087dbfa4b79e459e5R13-R14) [[2]](diffhunk://#diff-c6fd169b20ce5338b7e591ee0a8eed681d6bfbe936e3f0c087dbfa4b79e459e5L39-R43)…add BaseRepository for shared logic