### PR TITLE
Add Excel report export with filters and UI enhancements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     implementation(libs.androidx.gridlayout)
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("com.github.bumptech.glide:glide:4.16.0")
+    implementation("org.dhatim:fastexcel:0.20.2")
 }
 
 kapt {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,13 +18,13 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.accessoriesmanager"
+        android:theme="@style/Theme.FacilityTracker"
         >
         <activity
             android:name="com.example.accessoriesmanager.view.MainActivity"
             android:windowSoftInputMode="adjustPan"
             android:exported="true"
-            android:theme="@style/Theme.AccessoriesManager.Splash">
+            android:theme="@style/Theme.FacilityTracker.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/accessoriesmanager/report/ExcelReportGenerator.kt
+++ b/app/src/main/java/com/example/accessoriesmanager/report/ExcelReportGenerator.kt
@@ -1,0 +1,241 @@
+package com.example.accessoriesmanager.report
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import android.provider.MediaStore
+import com.example.accessoriesmanager.model.Installation
+import com.example.accessoriesmanager.model.headquarterLabelFromAny
+import com.example.accessoriesmanager.model.isPaidState
+import com.example.accessoriesmanager.model.isPartialState
+import com.example.accessoriesmanager.model.isUnpaidState
+import com.example.accessoriesmanager.model.matchesDates
+import com.example.accessoriesmanager.model.matchesStatus
+import com.example.accessoriesmanager.model.toLocalDate
+import com.example.accessoriesmanager.model.vehicleLabelFromAny
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.dhatim.fastexcel.Workbook
+import org.dhatim.fastexcel.Worksheet
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAdjusters
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Where the report ended up: [fileName]/[folder] for a confirmation message, [uri] + [mimeType]
+ * to share it (e.g. via `Intent.ACTION_SEND`) without needing a `FileProvider` — a MediaStore
+ * content:// uri is already shareable by the app that inserted it.
+ */
+data class ExportResult(val fileName: String, val folder: String, val uri: Uri, val mimeType: String)
+
+private const val XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+private const val DOWNLOADS_SUBFOLDER = "AccessoriesManager"
+
+/**
+ * Builds a two-sheet (Resumen / Detalle) .xlsx report of installations, filtered by [ReportFilter],
+ * and saves it directly into the public Downloads/AccessoriesManager folder via MediaStore
+ * (no storage permission needed on API 29+, which this app's minSdk already requires).
+ */
+@Singleton
+class ExcelReportGenerator @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    private val moneyFormat = "\"$\" #,##0"
+    private val dateFormat = "dd/mm/yyyy"
+
+    private val headerFill = "4472C4"
+    private val headerFont = "FFFFFF"
+
+    private val paidFill = "C6EFCE"
+    private val paidFont = "006100"
+    private val unpaidFill = "FFC7CE"
+    private val unpaidFont = "9C0006"
+    private val partialFill = "FFEB9C"
+    private val partialFont = "9C6500"
+
+    private val summaryHeaders = listOf(
+        "Fecha", "Orden", "Placa", "Serie", "Sede", "Vehículo",
+        "# Accesorios", "Total Trabajado", "Total Pagado", "Total No Pagado", "Estado", "Comentario"
+    )
+    private val summaryWidths = listOf(12.0, 8.0, 10.0, 10.0, 16.0, 18.0, 12.0, 14.0, 14.0, 14.0, 12.0, 28.0)
+
+    private val detailHeaders = listOf(
+        "Fecha", "Orden", "Placa", "Serie", "Sede", "Vehículo", "Accesorio", "Precio", "Pagado", "Estado Instalación"
+    )
+    private val detailWidths = listOf(12.0, 8.0, 10.0, 10.0, 16.0, 18.0, 20.0, 12.0, 10.0, 16.0)
+
+    suspend fun generate(installations: List<Installation>, filter: ReportFilter): ExportResult =
+        withContext(Dispatchers.IO) {
+            val (from, to) = filter.range.toDateBounds()
+            val filtered = installations
+                .filter { it.matchesDates(exact = null, from = from, to = to) }
+                .filter { it.matchesStatus(filter.status) }
+                .sortedByDescending { it.date?.seconds ?: 0L }
+
+            val stamp = DateTimeFormatter.ofPattern("yyyyMMdd_HHmm").format(LocalDateTime.now())
+            val fileName = "Reporte_Instalaciones_${filter.range.fileTag()}_$stamp.xlsx"
+            val relativeFolder = "${Environment.DIRECTORY_DOWNLOADS}/$DOWNLOADS_SUBFOLDER"
+
+            val resolver = context.contentResolver
+            val values = ContentValues().apply {
+                put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
+                put(MediaStore.MediaColumns.MIME_TYPE, XLSX_MIME)
+                put(MediaStore.MediaColumns.RELATIVE_PATH, relativeFolder)
+            }
+
+            val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+                ?: throw IllegalStateException("No se pudo crear el archivo en Descargas")
+
+            resolver.openOutputStream(uri)?.use { out ->
+                Workbook(out, "AccessoriesManager", "1.0").use { wb ->
+                    writeSummarySheet(wb.newWorksheet("Resumen"), filtered)
+                    writeDetailSheet(wb.newWorksheet("Detalle"), filtered)
+                }
+            } ?: throw IllegalStateException("No se pudo abrir el archivo para escritura")
+
+            ExportResult(fileName, relativeFolder, uri, XLSX_MIME)
+        }
+
+    // -------------------- Sheets --------------------
+
+    private fun writeSummarySheet(ws: Worksheet, installations: List<Installation>) {
+        writeHeader(ws, summaryHeaders)
+
+        installations.forEachIndexed { i, inst ->
+            val row = i + 1
+            ws.valueDate(row, 0, inst.date.toLocalDate())
+            ws.valueLong(row, 1, inst.order?.toLong())
+            ws.value(row, 2, inst.plate.orEmpty())
+            ws.value(row, 3, inst.serie.orEmpty())
+            ws.value(row, 4, headquarterLabelFromAny(inst.headquarter))
+            ws.value(row, 5, vehicleLabelFromAny(inst.vehicle))
+            ws.value(row, 6, (inst.accessories?.size ?: 0).toLong())
+            ws.value(row, 7, inst.totalWorked ?: 0L)
+            ws.value(row, 8, inst.totalPaid ?: 0L)
+            ws.value(row, 9, inst.totalUnpaid ?: 0L)
+            ws.value(row, 10, statusLabel(inst))
+            ws.value(row, 11, inst.comment.orEmpty())
+
+            ws.style(row, 0).format(dateFormat).set()
+            ws.style(row, 7).format(moneyFormat).set()
+            ws.style(row, 8).format(moneyFormat).set()
+            ws.style(row, 9).format(moneyFormat).set()
+            applyStatusStyle(ws, row, 10, inst)
+        }
+
+        val lastDataRow = installations.size
+        if (installations.isNotEmpty()) {
+            val totalsRow = lastDataRow + 1
+            ws.value(totalsRow, 5, "TOTAL")
+            ws.value(totalsRow, 7, installations.sumOf { it.totalWorked ?: 0L })
+            ws.value(totalsRow, 8, installations.sumOf { it.totalPaid ?: 0L })
+            ws.value(totalsRow, 9, installations.sumOf { it.totalUnpaid ?: 0L })
+            ws.range(totalsRow, 0, totalsRow, summaryHeaders.lastIndex).style().bold().set()
+            ws.style(totalsRow, 7).format(moneyFormat).bold().set()
+            ws.style(totalsRow, 8).format(moneyFormat).bold().set()
+            ws.style(totalsRow, 9).format(moneyFormat).bold().set()
+        }
+
+        ws.setAutoFilter(0, 0, lastDataRow, summaryHeaders.lastIndex)
+        ws.freezePane(0, 1)
+        summaryWidths.forEachIndexed { c, w -> ws.width(c, w) }
+    }
+
+    private fun writeDetailSheet(ws: Worksheet, installations: List<Installation>) {
+        writeHeader(ws, detailHeaders)
+
+        var row = 1
+        installations.forEach { inst ->
+            val date = inst.date.toLocalDate()
+            val plate = inst.plate.orEmpty()
+            val serie = inst.serie.orEmpty()
+            val headquarter = headquarterLabelFromAny(inst.headquarter)
+            val vehicle = vehicleLabelFromAny(inst.vehicle)
+            val status = statusLabel(inst)
+
+            inst.accessories.orEmpty().forEach { acc ->
+                ws.valueDate(row, 0, date)
+                ws.valueLong(row, 1, inst.order?.toLong())
+                ws.value(row, 2, plate)
+                ws.value(row, 3, serie)
+                ws.value(row, 4, headquarter)
+                ws.value(row, 5, vehicle)
+                ws.value(row, 6, acc.name.orEmpty())
+                ws.value(row, 7, acc.price)
+                ws.value(row, 8, if (acc.isPaid) "Sí" else "No")
+                ws.value(row, 9, status)
+
+                ws.style(row, 0).format(dateFormat).set()
+                ws.style(row, 7).format(moneyFormat).set()
+                val (fill, font) = if (acc.isPaid) paidFill to paidFont else unpaidFill to unpaidFont
+                ws.style(row, 8).fillColor(fill).fontColor(font).bold().set()
+
+                row++
+            }
+        }
+
+        val lastDataRow = (row - 1).coerceAtLeast(0)
+        ws.setAutoFilter(0, 0, lastDataRow, detailHeaders.lastIndex)
+        ws.freezePane(0, 1)
+        detailWidths.forEachIndexed { c, w -> ws.width(c, w) }
+    }
+
+    // -------------------- Helpers --------------------
+
+    private fun writeHeader(ws: Worksheet, headers: List<String>) {
+        headers.forEachIndexed { c, h -> ws.value(0, c, h) }
+        ws.range(0, 0, 0, headers.lastIndex).style()
+            .bold()
+            .fillColor(headerFill)
+            .fontColor(headerFont)
+            .horizontalAlignment("center")
+            .set()
+        ws.rowHeight(0, 18.0)
+    }
+
+    private fun statusLabel(inst: Installation): String = when {
+        inst.isPaidState() -> "Pagado"
+        inst.isUnpaidState() -> "No pagado"
+        inst.isPartialState() -> "Parcial"
+        else -> inst.state.orEmpty()
+    }
+
+    private fun applyStatusStyle(ws: Worksheet, row: Int, col: Int, inst: Installation) {
+        val (fill, font) = when {
+            inst.isPaidState() -> paidFill to paidFont
+            inst.isUnpaidState() -> unpaidFill to unpaidFont
+            inst.isPartialState() -> partialFill to partialFont
+            else -> return
+        }
+        ws.style(row, col).fillColor(fill).fontColor(font).bold().set()
+    }
+
+    private fun Worksheet.valueDate(row: Int, col: Int, date: LocalDate?) {
+        if (date != null) value(row, col, date) else value(row, col, "")
+    }
+
+    private fun Worksheet.valueLong(row: Int, col: Int, n: Long?) {
+        if (n != null) value(row, col, n) else value(row, col, "")
+    }
+
+    private fun ReportRange.toDateBounds(): Pair<LocalDate?, LocalDate?> = when (this) {
+        is ReportRange.All -> null to null
+        is ReportRange.Range -> from to to
+        is ReportRange.Month -> {
+            val first = LocalDate.of(year, month, 1)
+            first to first.with(TemporalAdjusters.lastDayOfMonth())
+        }
+    }
+
+    private fun ReportRange.fileTag(): String = when (this) {
+        is ReportRange.All -> "Todo"
+        is ReportRange.Range -> "${from}_a_$to"
+        is ReportRange.Month -> "%04d-%02d".format(year, month)
+    }
+}

--- a/app/src/main/java/com/example/accessoriesmanager/report/ExcelReportGenerator.kt
+++ b/app/src/main/java/com/example/accessoriesmanager/report/ExcelReportGenerator.kt
@@ -34,11 +34,11 @@ import javax.inject.Singleton
 data class ExportResult(val fileName: String, val folder: String, val uri: Uri, val mimeType: String)
 
 private const val XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-private const val DOWNLOADS_SUBFOLDER = "AccessoriesManager"
+private const val DOWNLOADS_SUBFOLDER = "FacilityTracker"
 
 /**
  * Builds a two-sheet (Resumen / Detalle) .xlsx report of installations, filtered by [ReportFilter],
- * and saves it directly into the public Downloads/AccessoriesManager folder via MediaStore
+ * and saves it directly into the public Downloads/FacilityTracker folder via MediaStore
  * (no storage permission needed on API 29+, which this app's minSdk already requires).
  */
 @Singleton
@@ -93,7 +93,7 @@ class ExcelReportGenerator @Inject constructor(
                 ?: throw IllegalStateException("No se pudo crear el archivo en Descargas")
 
             resolver.openOutputStream(uri)?.use { out ->
-                Workbook(out, "AccessoriesManager", "1.0").use { wb ->
+                Workbook(out, "FacilityTracker", "1.0").use { wb ->
                     writeSummarySheet(wb.newWorksheet("Resumen"), filtered)
                     writeDetailSheet(wb.newWorksheet("Detalle"), filtered)
                 }

--- a/app/src/main/java/com/example/accessoriesmanager/report/ReportFilter.kt
+++ b/app/src/main/java/com/example/accessoriesmanager/report/ReportFilter.kt
@@ -1,0 +1,15 @@
+package com.example.accessoriesmanager.report
+
+import java.time.LocalDate
+
+sealed class ReportRange {
+    data object All : ReportRange()
+    data class Range(val from: LocalDate, val to: LocalDate) : ReportRange()
+    data class Month(val year: Int, val month: Int) : ReportRange() // month 1..12
+}
+
+/** [status] uses the same UI values as [com.example.accessoriesmanager.model.matchesStatus]. */
+data class ReportFilter(
+    val range: ReportRange,
+    val status: String
+)

--- a/app/src/main/java/com/example/accessoriesmanager/view/fragment/InstallationsFragment.kt
+++ b/app/src/main/java/com/example/accessoriesmanager/view/fragment/InstallationsFragment.kt
@@ -1,12 +1,16 @@
 package com.example.accessoriesmanager.view.fragment
 
 import android.app.DatePickerDialog
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import android.widget.RadioGroup
+import android.widget.Spinner
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
@@ -20,8 +24,12 @@ import android.transition.TransitionManager
 import com.example.accessoriesmanager.R
 import com.example.accessoriesmanager.databinding.FragmentInstallationsBinding
 import com.example.accessoriesmanager.adapter.InstallationAdapter
+import com.example.accessoriesmanager.report.ExportResult
+import com.example.accessoriesmanager.report.ReportFilter
+import com.example.accessoriesmanager.report.ReportRange
 import com.example.accessoriesmanager.ui.showSnack
 import com.example.accessoriesmanager.viewmodel.InstallationViewModel
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
@@ -99,6 +107,8 @@ class InstallationsFragment : Fragment() {
 
         setupFiltersUi()
 
+        binding.btnExportReport.setOnClickListener { showExportDialog() }
+
         // -------------------- Summary toggle --------------------
         val summary = binding.includeSummary
         summary.sectionInstallations.isVisible = false
@@ -151,6 +161,21 @@ class InstallationsFragment : Fragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.error.collect { msg ->
                     msg?.let { showSnack(it) }
+                }
+            }
+        }
+
+        // -------------------- Reporte exportado --------------------
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.exportResult.collect { result ->
+                    Snackbar.make(
+                        binding.root,
+                        "Guardado en ${result.folder}/${result.fileName}",
+                        Snackbar.LENGTH_LONG
+                    ).setAction("Compartir") {
+                        shareExcelFile(result.uri, result.mimeType)
+                    }.show()
                 }
             }
         }
@@ -260,6 +285,77 @@ class InstallationsFragment : Fragment() {
             today.monthValue - 1,
             today.dayOfMonth
         ).apply { setTitle(title) }.show()
+    }
+
+    // -------------------- Exportar Excel --------------------
+
+    private val monthNames = listOf(
+        "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
+        "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"
+    )
+
+    private fun showExportDialog() {
+        val view = layoutInflater.inflate(R.layout.dialog_export_report, null)
+        val rgRange = view.findViewById<RadioGroup>(R.id.rgExportRange)
+        val containerMonth = view.findViewById<View>(R.id.containerExportMonth)
+        val spinnerMonth = view.findViewById<Spinner>(R.id.spinnerExportMonth)
+        val spinnerYear = view.findViewById<Spinner>(R.id.spinnerExportYear)
+        val spinnerStatus = view.findViewById<Spinner>(R.id.spinnerExportStatus)
+
+        val today = LocalDate.now()
+
+        spinnerMonth.adapter = ArrayAdapter(
+            requireContext(), android.R.layout.simple_spinner_item, monthNames
+        ).also { it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
+        spinnerMonth.setSelection(today.monthValue - 1)
+
+        val years = (today.year downTo today.year - 4).toList()
+        spinnerYear.adapter = ArrayAdapter(
+            requireContext(), android.R.layout.simple_spinner_item, years
+        ).also { it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
+
+        spinnerStatus.adapter = ArrayAdapter(
+            requireContext(), android.R.layout.simple_spinner_item, statusOptions
+        ).also { it.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
+        spinnerStatus.setSelection(statusOptions.indexOf(binding.spinnerStatus.selectedItem as? String).coerceAtLeast(0))
+
+        rgRange.setOnCheckedChangeListener { _, checkedId ->
+            containerMonth.isVisible = checkedId == R.id.rbExportMonth
+        }
+
+        androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setTitle("Exportar a Excel")
+            .setView(view)
+            .setPositiveButton("Generar") { _, _ ->
+                val range = when (rgRange.checkedRadioButtonId) {
+                    R.id.rbExportAll -> ReportRange.All
+                    R.id.rbExportMonth -> {
+                        val year = spinnerYear.selectedItem as Int
+                        val month = spinnerMonth.selectedItemPosition + 1
+                        ReportRange.Month(year, month)
+                    }
+                    else -> {
+                        val exact = viewModel.currentDateExact()
+                        val from = exact ?: viewModel.currentDateFrom()
+                        val to = exact ?: viewModel.currentDateTo()
+                        if (from != null && to != null) ReportRange.Range(from, to) else ReportRange.All
+                    }
+                }
+                val status = spinnerStatus.selectedItem as String
+                viewModel.exportReport(ReportFilter(range, status))
+                showSnack("Generando reporte…")
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun shareExcelFile(uri: Uri, mimeType: String) {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = mimeType
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        startActivity(Intent.createChooser(intent, "Compartir reporte"))
     }
 
     // -------------------- Dialogs --------------------

--- a/app/src/main/java/com/example/accessoriesmanager/viewmodel/InstallationViewModel.kt
+++ b/app/src/main/java/com/example/accessoriesmanager/viewmodel/InstallationViewModel.kt
@@ -9,13 +9,19 @@ import com.example.accessoriesmanager.model.isUnpaidState
 import com.example.accessoriesmanager.model.matchesDates
 import com.example.accessoriesmanager.model.matchesQuery
 import com.example.accessoriesmanager.model.matchesStatus
+import com.example.accessoriesmanager.report.ExcelReportGenerator
+import com.example.accessoriesmanager.report.ExportResult
+import com.example.accessoriesmanager.report.ReportFilter
 import com.example.accessoriesmanager.repository.InstallationRepository
 import com.google.firebase.firestore.ListenerRegistration
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
@@ -27,7 +33,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class InstallationViewModel @Inject constructor(
-    private val repo: InstallationRepository
+    private val repo: InstallationRepository,
+    private val excelReportGenerator: ExcelReportGenerator
 ) : ViewModel() {
 
     // ----- Fuente raw desde Firestore -----
@@ -36,6 +43,10 @@ class InstallationViewModel @Inject constructor(
     // ----- Error -----
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
+
+    // ----- Exportar Excel -----
+    private val _exportResult = MutableSharedFlow<ExportResult>(extraBufferCapacity = 1)
+    val exportResult: SharedFlow<ExportResult> = _exportResult.asSharedFlow()
 
     // ----- Filtros -----
     private val _query = MutableStateFlow("")
@@ -206,6 +217,7 @@ class InstallationViewModel @Inject constructor(
         setDefaultLast7Days()
     }
 
+    fun currentDateExact(): LocalDate? = _dateExact.value
     fun currentDateFrom(): LocalDate? = _dateFrom.value
     fun currentDateTo(): LocalDate? = _dateTo.value
 
@@ -214,6 +226,23 @@ class InstallationViewModel @Inject constructor(
         _dateExact.value = null
         _dateFrom.value = today.minusDays(6)
         _dateTo.value = today
+    }
+
+    // ------------- Exportar Excel -------------
+
+    /** Snapshot crudo de Firestore, sin los filtros de la pantalla — usado para el reporte. */
+    fun allInstallations(): List<Installation> = _all.value
+
+    fun exportReport(filter: ReportFilter) {
+        viewModelScope.launch {
+            try {
+                val result = excelReportGenerator.generate(allInstallations(), filter)
+                _exportResult.emit(result)
+            } catch (e: Exception) {
+                android.util.Log.e("INSTALLATIONS_VM", "Error generando reporte", e)
+                _error.emit("No se pudo generar el reporte: ${e.message}")
+            }
+        }
     }
 
     // ------------- Mark paid/unpaid -------------

--- a/app/src/main/res/drawable/ic_file_export.xml
+++ b/app/src/main/res/drawable/ic_file_export.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M480,640L240,400L296,344L440,488L440,160L520,160L520,488L664,344L720,400L480,640ZM160,800L160,640L240,640L240,720L720,720L720,640L800,640L800,800L160,800Z"/>
+
+</vector>

--- a/app/src/main/res/layout/dialog_export_report.xml
+++ b/app/src/main/res/layout/dialog_export_report.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Rango"
+            android:textStyle="bold"
+            android:textColor="@color/text_primary" />
+
+        <RadioGroup
+            android:id="@+id/rgExportRange"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginTop="4dp">
+
+            <RadioButton
+                android:id="@+id/rbExportAll"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Todos los registros" />
+
+            <RadioButton
+                android:id="@+id/rbExportCurrentFilter"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Usar el filtro de fecha actual de la pantalla" />
+
+            <RadioButton
+                android:id="@+id/rbExportMonth"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Mes específico" />
+
+        </RadioGroup>
+
+        <LinearLayout
+            android:id="@+id/containerExportMonth"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="4dp"
+            android:visibility="gone">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilExportMonth"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:hint="Mes">
+
+                <Spinner
+                    android:id="@+id/spinnerExportMonth"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:spinnerMode="dropdown" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilExportYear"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:layout_marginStart="8dp"
+                android:hint="Año">
+
+                <Spinner
+                    android:id="@+id/spinnerExportYear"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:spinnerMode="dropdown" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Estado de pago"
+            android:textStyle="bold"
+            android:textColor="@color/text_primary"
+            android:layout_marginTop="16dp" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilExportStatus"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginTop="4dp"
+            android:hint="Estado">
+
+            <Spinner
+                android:id="@+id/spinnerExportStatus"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:spinnerMode="dropdown" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_installations.xml
+++ b/app/src/main/res/layout/fragment_installations.xml
@@ -29,20 +29,37 @@
                 android:paddingBottom="12dp">
 
                 <!-- Título -->
-                <TextView
-                    android:id="@+id/tvTitle"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Instalaciones"
-                    android:textSize="22sp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
                     android:layout_marginTop="10dp"
                     android:paddingBottom="12dp"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    android:textAlignment="center" />
+                    android:paddingStart="16dp"
+                    android:paddingEnd="8dp">
+
+                    <TextView
+                        android:id="@+id/tvTitle"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Instalaciones"
+                        android:textSize="22sp"
+                        android:textStyle="bold"
+                        android:textColor="@color/text_primary"
+                        android:textAlignment="center" />
+
+                    <ImageButton
+                        android:id="@+id/btnExportReport"
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="Exportar a Excel"
+                        android:src="@drawable/ic_file_export"
+                        app:tint="@color/text_primary" />
+
+                </LinearLayout>
 
                 <!-- Resumen -->
                 <include

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base night application theme. -->
-    <style name="Theme.accessoriesmanager" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.FacilityTracker" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/primary_dark</item>
         <item name="colorOnPrimary">@color/on_primary</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.accessoriesmanager" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.FacilityTracker" parent="Theme.MaterialComponents.DayNight.NoActionBar">
     <!-- Colores de marca -->
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/primary_dark</item>
@@ -19,20 +19,20 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:navigationBarColor">@color/surface</item>
     </style>
-    <style name="Theme.accessoriesmanager.NoActionBar">
+    <style name="Theme.FacilityTracker.NoActionBar">
     </style>
 
-    <style name="Theme.accessoriesmanager.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="Theme.FacilityTracker.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
-    <style name="Theme.accessoriesmanager.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+    <style name="Theme.FacilityTracker.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
-    <style name="Theme.accessoriesmanager.TextTittle" parent="TextAppearance.AppCompat.Title">
+    <style name="Theme.FacilityTracker.TextTittle" parent="TextAppearance.AppCompat.Title">
         <item name="android:textSize">64sp</item>
         <item name="android:textColor">@color/text_primary</item>
         <item name="android:textStyle">bold</item>
     </style>
 
-    <style name="Theme.accessoriesmanager.TextSubTittle" parent="TextAppearance.AppCompat.Subhead">
+    <style name="Theme.FacilityTracker.TextSubTittle" parent="TextAppearance.AppCompat.Subhead">
         <item name="android:textSize">24sp</item>
         <item name="android:textColor">@color/text_secondary</item>
         <item name="android:textStyle">bold</item>
@@ -55,10 +55,10 @@
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 
-    <style name="Theme.AccessoriesManager.Splash" parent="Theme.SplashScreen">
+    <style name="Theme.FacilityTracker.Splash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/splash_background</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_foreground</item>
-        <item name="postSplashScreenTheme">@style/Theme.accessoriesmanager</item>
+        <item name="postSplashScreenTheme">@style/Theme.FacilityTracker</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This pull request introduces a major new feature: exporting installation reports to Excel (.xlsx) format, with flexible date and status filtering, and integrates this capability into the UI. Supporting changes include dependency additions, new report generation logic, and updates to the ViewModel and fragment to handle user interaction and file sharing. The app's theme is also updated to reflect a new branding.

**Excel Report Export Feature**

* Added the `fastexcel` library dependency to support Excel file generation (`app/build.gradle.kts`).
* Introduced `ExcelReportGenerator` and related data classes in `report/ExcelReportGenerator.kt` to generate multi-sheet Excel reports of installations, filtered by user-selected criteria, and save them to the Downloads folder using MediaStore.
* Added `ReportFilter` and `ReportRange` classes for specifying report export filters, supporting all, date range, or month-based exports (`report/ReportFilter.kt`).

**UI Integration and User Flow**

* Updated `InstallationsFragment` to add an "Export Report" button, show a dialog for selecting export filters (date range, month, status), and handle the export action. After export, a Snackbar confirms the save location and offers a "Share" action to send the Excel file via other apps. [[1]](diffhunk://#diff-996e253b6b36ea13c3e6a6ba893d8c3ebe75dcbdf09fa4bc1b7254b367a46f3dR4-R13) [[2]](diffhunk://#diff-996e253b6b36ea13c3e6a6ba893d8c3ebe75dcbdf09fa4bc1b7254b367a46f3dR27-R32) [[3]](diffhunk://#diff-996e253b6b36ea13c3e6a6ba893d8c3ebe75dcbdf09fa4bc1b7254b367a46f3dR110-R111) [[4]](diffhunk://#diff-996e253b6b36ea13c3e6a6ba893d8c3ebe75dcbdf09fa4bc1b7254b367a46f3dR168-R182) [[5]](diffhunk://#diff-996e253b6b36ea13c3e6a6ba893d8c3ebe75dcbdf09fa4bc1b7254b367a46f3dR290-R360)

**ViewModel and Data Flow**

* Extended `InstallationViewModel` to inject `ExcelReportGenerator`, expose an `exportResult` flow for export completion, and provide an `exportReport` method that generates and emits the report, handling errors gracefully. [[1]](diffhunk://#diff-0b799be19944d79bfc7a95aedc409ade518e0281c4c587f6fc87ed781cd4ea70R12-R24) [[2]](diffhunk://#diff-0b799be19944d79bfc7a95aedc409ade518e0281c4c587f6fc87ed781cd4ea70L30-R37) [[3]](diffhunk://#diff-0b799be19944d79bfc7a95aedc409ade518e0281c4c587f6fc87ed781cd4ea70R47-R50) [[4]](diffhunk://#diff-0b799be19944d79bfc7a95aedc409ade518e0281c4c587f6fc87ed781cd4ea70R220) [[5]](diffhunk://#diff-0b799be19944d79bfc7a95aedc409ade518e0281c4c587f6fc87ed781cd4ea70R231-R247)

**Branding and Theme**

* Changed the app's theme and splash screen references in `AndroidManifest.xml` to use the new `FacilityTracker` branding.